### PR TITLE
fix: AI scoring module - complete all 7 fixes with passing tests

### DIFF
--- a/backend/llm-wiki-adapter/src/main/java/com/llmwiki/adapter/api/OpenAiApiClient.java
+++ b/backend/llm-wiki-adapter/src/main/java/com/llmwiki/adapter/api/OpenAiApiClient.java
@@ -29,14 +29,14 @@ public class OpenAiApiClient implements AiApiClient {
 
     private static final String SCORE_SYSTEM_PROMPT = """
             You are a document quality analyzer. Score the document on these dimensions (0-10 each):
-            1. Relevance - How relevant is this to a knowledge base?
-            2. Completeness - Does it cover the topic adequately?
-            3. Accuracy - Is the information factually sound?
-            4. Clarity - Is it well-written and understandable?
-            5. Structure - Is it well-organized?
-            
+            1. information_density - How much useful information does the document contain per unit of text?
+            2. entity_richness - How many notable entities (people, organizations, technologies, concepts) are mentioned?
+            3. knowledge_independence - Can the document be understood as a standalone piece without external context?
+            4. structure_integrity - Is the document well-organized with clear sections and logical flow?
+            5. timeliness - Is the information current and up-to-date?
+
             Respond in JSON format:
-            {"scores":{"relevance":N,"completeness":N,"accuracy":N,"clarity":N,"structure":N},"overall_score":N,"reason":"explanation","key_entities":["entity1","entity2"],"suggested_tags":["tag1","tag2"]}
+            {"scores":{"information_density":N,"entity_richness":N,"knowledge_independence":N,"structure_integrity":N,"timeliness":N},"overall_score":N,"reason":"explanation","key_entities":["entity1","entity2"],"suggested_tags":["tag1","tag2"]}
             """;
 
     private static final String ENTITY_SYSTEM_PROMPT = """

--- a/backend/llm-wiki-adapter/src/main/java/com/llmwiki/adapter/dto/ScoreResult.java
+++ b/backend/llm-wiki-adapter/src/main/java/com/llmwiki/adapter/dto/ScoreResult.java
@@ -1,26 +1,20 @@
 package com.llmwiki.adapter.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
 public class ScoreResult {
     private Map<String, Integer> scores;
     private BigDecimal overallScore;
     private String reason;
     private List<String> keyEntities;
     private List<String> suggestedTags;
-
-    public ScoreResult() {}
-
-    public Map<String, Integer> getScores() { return scores; }
-    public void setScores(Map<String, Integer> scores) { this.scores = scores; }
-    public BigDecimal getOverallScore() { return overallScore; }
-    public void setOverallScore(BigDecimal overallScore) { this.overallScore = overallScore; }
-    public String getReason() { return reason; }
-    public void setReason(String reason) { this.reason = reason; }
-    public List<String> getKeyEntities() { return keyEntities; }
-    public void setKeyEntities(List<String> keyEntities) { this.keyEntities = keyEntities; }
-    public List<String> getSuggestedTags() { return suggestedTags; }
-    public void setSuggestedTags(List<String> suggestedTags) { this.suggestedTags = suggestedTags; }
 }

--- a/backend/llm-wiki-domain/src/main/java/com/llmwiki/domain/page/entity/Page.java
+++ b/backend/llm-wiki-domain/src/main/java/com/llmwiki/domain/page/entity/Page.java
@@ -41,6 +41,7 @@ public class Page {
     @Builder.Default
     private Boolean contested = false;
 
+    @Column(name = "score")
     private BigDecimal aiScore;
 
     @Column(columnDefinition = "TEXT")

--- a/backend/llm-wiki-service/src/main/java/com/llmwiki/service/pipeline/PipelineService.java
+++ b/backend/llm-wiki-service/src/main/java/com/llmwiki/service/pipeline/PipelineService.java
@@ -28,6 +28,7 @@ import com.llmwiki.domain.processing.repository.ProcessingLogRepository;
 import com.llmwiki.domain.sync.entity.RawDocument;
 import com.llmwiki.domain.sync.repository.RawDocumentRepository;
 import com.llmwiki.domain.config.repository.SystemConfigRepository;
+import com.llmwiki.service.scoring.ScoringService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -58,6 +59,7 @@ public class PipelineService {
 
     private final AiApiClient aiClient;
     private final EmbeddingClient embeddingClient;
+    private final ScoringService scoringService;
 
     @Transactional
     public void processDocument(UUID rawDocId) {
@@ -66,14 +68,13 @@ public class PipelineService {
 
         log.info("Starting pipeline for document: {} ({})", doc.getTitle(), doc.getId());
 
-        BigDecimal threshold = getScoreThreshold();
-
         // Step 1: Score
         ScoreResult scoreResult = executeWithRetry(rawDocId, "SCORE", () -> scoreDocument(doc));
         if (scoreResult == null) {
             return; // already in DLQ
         }
-        if (scoreResult.getOverallScore().compareTo(threshold) < 0) {
+        if (!scoringService.passesThreshold(scoreResult)) {
+            BigDecimal threshold = scoringService.getThreshold();
             log.info("Document {} score {} below threshold {}, skipping", doc.getId(), scoreResult.getOverallScore(), threshold);
             saveStepLog(rawDocId, "SCORE", StepStatus.SKIPPED, "Score " + scoreResult.getOverallScore() + " below threshold " + threshold);
             return;
@@ -228,13 +229,7 @@ public class PipelineService {
     }
 
     private ScoreResult scoreDocument(RawDocument doc) {
-        return aiClient.score(doc.getContent());
-    }
-
-    private BigDecimal getScoreThreshold() {
-        return configRepo.findByKey("scoring.threshold")
-                .map(c -> new BigDecimal(c.getValue()))
-                .orElse(new BigDecimal("60.0"));
+        return scoringService.scoreDocument(doc.getContent());
     }
 
     private ExtractionResult extractEntities(RawDocument doc) {
@@ -327,7 +322,7 @@ public class PipelineService {
 
         StringBuilder content = new StringBuilder();
         content.append("# ").append(doc.getTitle()).append("\n\n");
-        content.append("> Score: ").append(score.getOverallScore()).append("/100\n");
+        content.append("> Score: ").append(score.getOverallScore()).append("/10\n");
         content.append("> Source: ").append(doc.getSourceUrl() != null ? doc.getSourceUrl() : "N/A").append("\n\n");
 
         if (!entities.getEntities().isEmpty()) {

--- a/backend/llm-wiki-service/src/main/java/com/llmwiki/service/scoring/ScoringService.java
+++ b/backend/llm-wiki-service/src/main/java/com/llmwiki/service/scoring/ScoringService.java
@@ -8,11 +8,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.HashMap;
 import java.util.Map;
 
 /**
- * 评分服务：调用AI对文档进行多维度评分，并判断是否通过阈值。
+ * 评分服务：调用AI对文档进行多维度评分，计算加权分数，并判断是否通过阈值。
  */
 @Service
 @RequiredArgsConstructor
@@ -27,20 +28,43 @@ public class ScoringService {
     private static final BigDecimal DEFAULT_THRESHOLD = new BigDecimal("5.0");
 
     /**
-     * 对文档内容进行AI评分。
+     * 对文档内容进行AI评分，并计算加权总分。
      *
      * @param content 文档内容
-     * @return 评分结果
+     * @return 评分结果（overallScore 为加权计算后的分数）
      */
     public ScoreResult scoreDocument(String content) {
         if (content == null || content.isBlank()) {
             log.warn("Empty content provided for scoring");
-            ScoreResult emptyResult = new ScoreResult();
-            emptyResult.setOverallScore(BigDecimal.ZERO);
-            emptyResult.setReason("内容为空");
-            return emptyResult;
+            return ScoreResult.builder()
+                    .overallScore(BigDecimal.ZERO)
+                    .reason("内容为空")
+                    .build();
         }
-        return aiClient.score(content);
+        ScoreResult result = aiClient.score(content);
+        // 计算加权分数并覆盖 overallScore
+        BigDecimal weightedScore = calculateWeightedScore(result.getScores());
+        result.setOverallScore(weightedScore);
+        return result;
+    }
+
+    /**
+     * 根据各维度分数和权重计算加权总分。
+     *
+     * @param scores 各维度分数映射
+     * @return 加权总分（0-10）
+     */
+    public BigDecimal calculateWeightedScore(Map<String, Integer> scores) {
+        if (scores == null || scores.isEmpty()) {
+            return BigDecimal.ZERO;
+        }
+        Map<String, BigDecimal> weights = getScoreWeights();
+        BigDecimal weightedSum = BigDecimal.ZERO;
+        for (Map.Entry<String, Integer> entry : scores.entrySet()) {
+            BigDecimal weight = weights.getOrDefault(entry.getKey(), BigDecimal.ZERO);
+            weightedSum = weightedSum.add(BigDecimal.valueOf(entry.getValue()).multiply(weight));
+        }
+        return weightedSum.setScale(2, RoundingMode.HALF_UP);
     }
 
     /**
@@ -65,6 +89,24 @@ public class ScoringService {
                 .orElse(DEFAULT_THRESHOLD);
 
         return result.getOverallScore().compareTo(threshold) >= 0;
+    }
+
+    /**
+     * 获取评分阈值。
+     *
+     * @return 阈值（默认 5.0，0-10 分制）
+     */
+    public BigDecimal getThreshold() {
+        return configRepo.findByKey(THRESHOLD_KEY)
+                .map(config -> {
+                    try {
+                        return new BigDecimal(config.getValue());
+                    } catch (NumberFormatException e) {
+                        log.warn("Invalid threshold value: {}, using default", config.getValue());
+                        return DEFAULT_THRESHOLD;
+                    }
+                })
+                .orElse(DEFAULT_THRESHOLD);
     }
 
     /**

--- a/backend/llm-wiki-service/src/test/java/com/llmwiki/service/pipeline/PipelineServiceTest.java
+++ b/backend/llm-wiki-service/src/test/java/com/llmwiki/service/pipeline/PipelineServiceTest.java
@@ -23,6 +23,7 @@ import com.llmwiki.domain.pipeline.repository.DeadLetterQueueRepository;
 import com.llmwiki.domain.processing.repository.ProcessingLogRepository;
 import com.llmwiki.domain.sync.entity.RawDocument;
 import com.llmwiki.domain.sync.repository.RawDocumentRepository;
+import com.llmwiki.service.scoring.ScoringService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -54,6 +55,7 @@ class PipelineServiceTest {
     @Mock SystemConfigRepository configRepo;
     @Mock AiApiClient aiClient;
     @Mock EmbeddingClient embeddingClient;
+    @Mock ScoringService scoringService;
 
     @InjectMocks
     PipelineService pipelineService;
@@ -73,9 +75,9 @@ class PipelineServiceTest {
                 .contentHash("abc123").build();
 
         scoreResult = new ScoreResult();
-        scoreResult.setOverallScore(new BigDecimal("75.0"));
+        scoreResult.setOverallScore(new BigDecimal("7.5"));
         scoreResult.setReason("Good quality");
-        scoreResult.setScores(Map.of("relevance", 80, "completeness", 70));
+        scoreResult.setScores(Map.of("information_density", 8, "entity_richness", 7));
         scoreResult.setKeyEntities(List.of("Java"));
         scoreResult.setSuggestedTags(List.of("programming", "language"));
 
@@ -93,17 +95,18 @@ class PipelineServiceTest {
     @Test
     void processDocument_shouldSkipWhenScoreBelowThreshold() {
         ScoreResult lowScore = new ScoreResult();
-        lowScore.setOverallScore(new BigDecimal("30.0"));
+        lowScore.setOverallScore(new BigDecimal("3.0"));
         lowScore.setReason("Low quality");
 
         when(rawDocRepo.findById(rawDocId)).thenReturn(Optional.of(doc));
-        when(configRepo.findByKey("scoring.threshold")).thenReturn(Optional.empty());
-        when(aiClient.score(doc.getContent())).thenReturn(lowScore);
+        when(configRepo.findByKey("pipeline.max.retries")).thenReturn(Optional.empty());
+        when(scoringService.scoreDocument(doc.getContent())).thenReturn(lowScore);
+        when(scoringService.passesThreshold(lowScore)).thenReturn(false);
         when(procLogRepo.save(any())).thenAnswer(i -> i.getArgument(0));
 
         pipelineService.processDocument(rawDocId);
 
-        verify(aiClient).score(doc.getContent());
+        verify(scoringService).scoreDocument(doc.getContent());
         verify(pageRepo, never()).save(any());
         verify(kgNodeRepo, never()).save(any());
         verify(procLogRepo, atLeastOnce()).save(any());
@@ -112,8 +115,9 @@ class PipelineServiceTest {
     @Test
     void processDocument_shouldProcessWhenScoreAboveThreshold() {
         when(rawDocRepo.findById(rawDocId)).thenReturn(Optional.of(doc));
-        when(configRepo.findByKey("scoring.threshold")).thenReturn(Optional.empty());
-        when(aiClient.score(doc.getContent())).thenReturn(scoreResult);
+        when(configRepo.findByKey("pipeline.max.retries")).thenReturn(Optional.empty());
+        when(scoringService.scoreDocument(doc.getContent())).thenReturn(scoreResult);
+        when(scoringService.passesThreshold(scoreResult)).thenReturn(true);
         when(aiClient.extractEntities(doc.getContent())).thenReturn(entities);
         when(aiClient.extractConcepts(doc.getContent())).thenReturn(concepts);
         when(kgNodeRepo.findByNameAndNodeType("Java", NodeType.ENTITY)).thenReturn(Optional.empty());
@@ -135,7 +139,7 @@ class PipelineServiceTest {
 
         pipelineService.processDocument(rawDocId);
 
-        verify(aiClient).score(doc.getContent());
+        verify(scoringService).scoreDocument(doc.getContent());
         verify(aiClient).extractEntities(doc.getContent());
         verify(aiClient).extractConcepts(doc.getContent());
         verify(kgNodeRepo, atLeast(2)).save(any(KgNode.class));
@@ -149,8 +153,9 @@ class PipelineServiceTest {
                 .id(UUID.randomUUID()).name("Java").nodeType(NodeType.ENTITY).build();
 
         when(rawDocRepo.findById(rawDocId)).thenReturn(Optional.of(doc));
-        when(configRepo.findByKey("scoring.threshold")).thenReturn(Optional.empty());
-        when(aiClient.score(doc.getContent())).thenReturn(scoreResult);
+        when(configRepo.findByKey("pipeline.max.retries")).thenReturn(Optional.empty());
+        when(scoringService.scoreDocument(doc.getContent())).thenReturn(scoreResult);
+        when(scoringService.passesThreshold(scoreResult)).thenReturn(true);
         when(aiClient.extractEntities(doc.getContent())).thenReturn(entities);
         when(aiClient.extractConcepts(doc.getContent())).thenReturn(concepts);
         when(kgNodeRepo.findByNameAndNodeType("Java", NodeType.ENTITY)).thenReturn(Optional.of(existingNode));

--- a/backend/llm-wiki-service/src/test/java/com/llmwiki/service/pipeline/PipelineServiceTest.java
+++ b/backend/llm-wiki-service/src/test/java/com/llmwiki/service/pipeline/PipelineServiceTest.java
@@ -192,8 +192,9 @@ class PipelineServiceTest {
                 .id(UUID.randomUUID()).name("OOP").nodeType(NodeType.CONCEPT).build();
 
         when(rawDocRepo.findById(rawDocId)).thenReturn(Optional.of(doc));
-        when(configRepo.findByKey("scoring.threshold")).thenReturn(Optional.empty());
-        when(aiClient.score(doc.getContent())).thenReturn(scoreResult);
+        when(configRepo.findByKey("pipeline.max.retries")).thenReturn(Optional.empty());
+        when(scoringService.scoreDocument(doc.getContent())).thenReturn(scoreResult);
+        when(scoringService.passesThreshold(scoreResult)).thenReturn(true);
         when(aiClient.extractEntities(doc.getContent())).thenReturn(entities);
         when(aiClient.extractConcepts(doc.getContent())).thenReturn(concepts);
         when(kgNodeRepo.findByNameAndNodeType("Java", NodeType.ENTITY)).thenReturn(Optional.of(entityNode));
@@ -226,8 +227,9 @@ class PipelineServiceTest {
                 .weight(BigDecimal.valueOf(0.5)).build();
 
         when(rawDocRepo.findById(rawDocId)).thenReturn(Optional.of(doc));
-        when(configRepo.findByKey("scoring.threshold")).thenReturn(Optional.empty());
-        when(aiClient.score(doc.getContent())).thenReturn(scoreResult);
+        when(configRepo.findByKey("pipeline.max.retries")).thenReturn(Optional.empty());
+        when(scoringService.scoreDocument(doc.getContent())).thenReturn(scoreResult);
+        when(scoringService.passesThreshold(scoreResult)).thenReturn(true);
         when(aiClient.extractEntities(doc.getContent())).thenReturn(entities);
         when(aiClient.extractConcepts(doc.getContent())).thenReturn(concepts);
         when(kgNodeRepo.findByNameAndNodeType("Java", NodeType.ENTITY)).thenReturn(Optional.of(entityNode));
@@ -250,8 +252,9 @@ class PipelineServiceTest {
     @Test
     void processDocument_shouldAutoSubmitForApproval() {
         when(rawDocRepo.findById(rawDocId)).thenReturn(Optional.of(doc));
-        when(configRepo.findByKey("scoring.threshold")).thenReturn(Optional.empty());
-        when(aiClient.score(doc.getContent())).thenReturn(scoreResult);
+        when(configRepo.findByKey("pipeline.max.retries")).thenReturn(Optional.empty());
+        when(scoringService.scoreDocument(doc.getContent())).thenReturn(scoreResult);
+        when(scoringService.passesThreshold(scoreResult)).thenReturn(true);
         when(aiClient.extractEntities(doc.getContent())).thenReturn(entities);
         when(aiClient.extractConcepts(doc.getContent())).thenReturn(concepts);
         when(kgNodeRepo.findByNameAndNodeType(any(), any())).thenReturn(Optional.empty());
@@ -290,8 +293,9 @@ class PipelineServiceTest {
     @Test
     void generateUniqueSlug_shouldAppendSuffixForDuplicates() {
         when(rawDocRepo.findById(rawDocId)).thenReturn(Optional.of(doc));
-        when(configRepo.findByKey("scoring.threshold")).thenReturn(Optional.empty());
-        when(aiClient.score(doc.getContent())).thenReturn(scoreResult);
+        when(configRepo.findByKey("pipeline.max.retries")).thenReturn(Optional.empty());
+        when(scoringService.scoreDocument(doc.getContent())).thenReturn(scoreResult);
+        when(scoringService.passesThreshold(scoreResult)).thenReturn(true);
         when(aiClient.extractEntities(doc.getContent())).thenReturn(entities);
         when(aiClient.extractConcepts(doc.getContent())).thenReturn(concepts);
         when(kgNodeRepo.findByNameAndNodeType(any(), any())).thenReturn(Optional.empty());
@@ -323,17 +327,16 @@ class PipelineServiceTest {
     @Test
     void processDocument_shouldRetryOnFailureAndSaveToDlq() {
         when(rawDocRepo.findById(rawDocId)).thenReturn(Optional.of(doc));
-        when(configRepo.findByKey("scoring.threshold")).thenReturn(Optional.empty());
         when(configRepo.findByKey("pipeline.max.retries")).thenReturn(Optional.empty());
         // Score always fails
-        when(aiClient.score(doc.getContent())).thenThrow(new RuntimeException("AI service unavailable"));
+        when(scoringService.scoreDocument(doc.getContent())).thenThrow(new RuntimeException("AI service unavailable"));
         when(procLogRepo.save(any())).thenAnswer(i -> i.getArgument(0));
         when(deadLetterQueueRepo.save(any(DeadLetterQueue.class))).thenAnswer(i -> i.getArgument(0));
 
         pipelineService.processDocument(rawDocId);
 
         // Should have retried 3 times
-        verify(aiClient, times(3)).score(doc.getContent());
+        verify(scoringService, times(3)).scoreDocument(doc.getContent());
         // Should have saved to DLQ
         ArgumentCaptor<DeadLetterQueue> dlqCaptor = ArgumentCaptor.forClass(DeadLetterQueue.class);
         verify(deadLetterQueueRepo).save(dlqCaptor.capture());
@@ -348,18 +351,18 @@ class PipelineServiceTest {
     @Test
     void processDocument_shouldSucceedOnRetry() {
         when(rawDocRepo.findById(rawDocId)).thenReturn(Optional.of(doc));
-        when(configRepo.findByKey("scoring.threshold")).thenReturn(Optional.empty());
         when(configRepo.findByKey("pipeline.max.retries")).thenReturn(Optional.empty());
         // First call fails, second succeeds
-        when(aiClient.score(doc.getContent()))
+        when(scoringService.scoreDocument(doc.getContent()))
                 .thenThrow(new RuntimeException("Transient error"))
                 .thenReturn(scoreResult);
+        when(scoringService.passesThreshold(scoreResult)).thenReturn(true);
         when(procLogRepo.save(any())).thenAnswer(i -> i.getArgument(0));
 
         pipelineService.processDocument(rawDocId);
 
-        // Should have called score twice (1 fail + 1 success)
-        verify(aiClient, times(2)).score(doc.getContent());
+        // Should have called scoreDocument twice (1 fail + 1 success)
+        verify(scoringService, times(2)).scoreDocument(doc.getContent());
         // Should NOT have saved to DLQ
         verify(deadLetterQueueRepo, never()).save(any());
     }
@@ -367,9 +370,9 @@ class PipelineServiceTest {
     @Test
     void processDocument_shouldSaveDlqForEntityExtractionFailure() {
         when(rawDocRepo.findById(rawDocId)).thenReturn(Optional.of(doc));
-        when(configRepo.findByKey("scoring.threshold")).thenReturn(Optional.empty());
         when(configRepo.findByKey("pipeline.max.retries")).thenReturn(Optional.empty());
-        when(aiClient.score(doc.getContent())).thenReturn(scoreResult);
+        when(scoringService.scoreDocument(doc.getContent())).thenReturn(scoreResult);
+        when(scoringService.passesThreshold(scoreResult)).thenReturn(true);
         when(aiClient.extractEntities(doc.getContent())).thenThrow(new RuntimeException("Extraction failed"));
         when(procLogRepo.save(any())).thenAnswer(i -> i.getArgument(0));
         when(deadLetterQueueRepo.save(any(DeadLetterQueue.class))).thenAnswer(i -> i.getArgument(0));
@@ -400,8 +403,9 @@ class PipelineServiceTest {
 
         // Mock successful pipeline execution
         when(rawDocRepo.findById(rawDocId)).thenReturn(Optional.of(doc));
-        when(configRepo.findByKey("scoring.threshold")).thenReturn(Optional.empty());
-        when(aiClient.score(doc.getContent())).thenReturn(scoreResult);
+        when(configRepo.findByKey("pipeline.max.retries")).thenReturn(Optional.empty());
+        when(scoringService.scoreDocument(doc.getContent())).thenReturn(scoreResult);
+        when(scoringService.passesThreshold(scoreResult)).thenReturn(true);
         when(procLogRepo.save(any())).thenAnswer(i -> i.getArgument(0));
 
         pipelineService.retryDeadLetter(dlqId);

--- a/backend/llm-wiki-web/src/main/resources/db/migration/V1__init_schema.sql
+++ b/backend/llm-wiki-web/src/main/resources/db/migration/V1__init_schema.sql
@@ -199,9 +199,10 @@ CREATE TABLE system_config (
 -- Seed: default scoring threshold config
 -- =============================================
 INSERT INTO system_config (config_key, config_value, description) VALUES
-('scoring.threshold', '60.0', 'Minimum AI score (0-100) for document processing'),
-('scoring.dimensions', 'relevance,completeness,accuracy,clarity', 'Scoring dimensions'),
+('scoring.threshold', '5.0', 'Minimum AI score (0-10) for document processing'),
+('scoring.dimensions', 'information_density,entity_richness,knowledge_independence,structure_integrity,timeliness', 'Scoring dimensions'),
 ('embedding.dimension', '1536', 'Embedding vector dimension'),
 ('embedding.model', 'text-embedding-ada-002', 'Embedding model name'),
 ('sync.batch.size', '50', 'Max documents per sync batch'),
-('pipeline.max.retries', '3', 'Max retries for failed pipeline steps');
+('pipeline.max.retries', '3', 'Max retries for failed pipeline steps'),
+('scoring.weights', 'information_density:0.3,entity_richness:0.25,knowledge_independence:0.2,structure_integrity:0.15,timeliness:0.1', 'Scoring dimension weights');


### PR DESCRIPTION
## 修复 AI 评分模块的 7 个问题

### 🔴 问题 1: 评分维度名称不一致
**文件:** `OpenAiApiClient.java`
- Prompt 维度从 relevance/completeness/accuracy/clarity/structure 改为 information_density/entity_richness/knowledge_independence/structure_integrity/timeliness
- JSON 响应格式中的 key 同步更新

### 🔴 问题 2+3: 阈值分制混乱 + PipelineService 绕过 ScoringService
**文件:** `PipelineService.java`
- 注入 ScoringService，使用 scoringService.scoreDocument() 和 scoringService.passesThreshold()
- 删除重复的 getScoreThreshold() 方法和直接调用 aiClient.score() 的逻辑
- 阈值统一为 5.0 (0-10 分制)

### 🟡 问题 5: 加权评分计算未执行
**文件:** `ScoringService.java`
- 新增 calculateWeightedScore() 方法
- scoreDocument() 在获取 AI 返回结果后调用加权计算覆盖 overallScore
- 新增 getThreshold() 公共方法

### 🟡 问题 4: ScoreResult 缺少 Lombok 注解
**文件:** `ScoreResult.java`
- 添加 @Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder

### 🟡 问题 6: Page 实体字段名与数据库列名不匹配
**文件:** `Page.java`
- aiScore 字段添加 @Column(name = "score")

### 🟡 数据库种子数据修复
**文件:** `V1__init_schema.sql`
- scoring.threshold: 60.0 → 5.0
- scoring.dimensions: 更新为正确的维度名称
- 新增 scoring.weights 种子数据

### 测试修复
- 更新 PipelineServiceTest 中所有 mock 从 aiClient.score() 改为 scoringService.scoreDocument()
- 添加 scoringService.passesThreshold() mock
- 修复 configRepo.findByKey 的参数从 scoring.threshold 改为 pipeline.max.retries

Closes #7