### PR TITLE
fix: validate password in AuthController.login (#13)

### DIFF
--- a/backend/llm-wiki-web/src/main/java/com/llmwiki/web/controller/AuthController.java
+++ b/backend/llm-wiki-web/src/main/java/com/llmwiki/web/controller/AuthController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
+import jakarta.annotation.PostConstruct;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -23,10 +24,12 @@ public class AuthController {
     private final PasswordEncoder passwordEncoder;
 
     // 内存用户存储（仅用于开发/演示）
-    private static final Map<String, String> USERS = new ConcurrentHashMap<>();
-    static {
-        USERS.put("admin", "ADMIN");
-        USERS.put("user", "USER");
+    private Map<String, String> USERS = new ConcurrentHashMap<>();
+
+    @PostConstruct
+    public void init() {
+        USERS.put("admin", passwordEncoder.encode("admin_password"));
+        USERS.put("user", passwordEncoder.encode("user_password"));
     }
 
     /**
@@ -34,12 +37,16 @@ public class AuthController {
      */
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody LoginRequest request) {
-        // 简化版：任何密码都能登录（实际应验证密码）
-        String role = USERS.get(request.getUsername());
-        if (role == null) {
+        String storedHash = USERS.get(request.getUsername());
+        if (storedHash == null) {
             return ResponseEntity.status(401).body(Map.of("error", "用户不存在"));
         }
 
+        if (!passwordEncoder.matches(request.getPassword(), storedHash)) {
+            return ResponseEntity.status(401).body(Map.of("error", "密码错误"));
+        }
+
+        String role = request.getUsername().equals("admin") ? "ADMIN" : "USER";
         String token = tokenProvider.createToken(request.getUsername(), role);
         return ResponseEntity.ok(Map.of(
                 "token", token,
@@ -56,7 +63,8 @@ public class AuthController {
         if (USERS.containsKey(request.getUsername())) {
             return ResponseEntity.badRequest().body(Map.of("error", "用户名已存在"));
         }
-        USERS.put(request.getUsername(), "USER");
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+        USERS.put(request.getUsername(), encodedPassword);
         String token = tokenProvider.createToken(request.getUsername(), "USER");
         return ResponseEntity.ok(Map.of(
                 "token", token,

--- a/backend/llm-wiki-web/src/test/java/com/llmwiki/web/controller/AuthControllerTest.java
+++ b/backend/llm-wiki-web/src/test/java/com/llmwiki/web/controller/AuthControllerTest.java
@@ -1,0 +1,93 @@
+package com.llmwiki.web.controller;
+
+import com.llmwiki.web.security.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthControllerTest {
+
+    @Mock
+    JwtTokenProvider tokenProvider;
+
+    @Mock
+    PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    AuthController controller;
+
+    @BeforeEach
+    void setUp() {
+        when(passwordEncoder.encode("admin_password")).thenReturn("encoded_admin");
+        when(passwordEncoder.encode("user_password")).thenReturn("encoded_user");
+        controller.init();
+    }
+
+    @Test
+    void loginWithCorrectPasswordSucceeds() {
+        when(passwordEncoder.matches("password123", "encoded_admin")).thenReturn(true);
+        when(tokenProvider.createToken("admin", "ADMIN")).thenReturn("fake-jwt-token");
+
+        AuthController.LoginRequest request = new AuthController.LoginRequest();
+        request.setUsername("admin");
+        request.setPassword("password123");
+
+        var response = controller.login(request);
+
+        assertEquals(200, response.getStatusCodeValue());
+        Map<String, String> body = (Map<String, String>) response.getBody();
+        assertEquals("fake-jwt-token", body.get("token"));
+        assertEquals("admin", body.get("username"));
+        assertEquals("ADMIN", body.get("role"));
+    }
+
+    @Test
+    void loginWithWrongPasswordReturns401() {
+        when(passwordEncoder.matches(anyString(), anyString())).thenReturn(false);
+
+        AuthController.LoginRequest request = new AuthController.LoginRequest();
+        request.setUsername("admin");
+        request.setPassword("wrong");
+
+        var response = controller.login(request);
+
+        assertEquals(401, response.getStatusCodeValue());
+    }
+
+    @Test
+    void loginWithNonExistentUsernameReturns401() {
+        AuthController.LoginRequest request = new AuthController.LoginRequest();
+        request.setUsername("nonexistent");
+        request.setPassword("password");
+
+        var response = controller.login(request);
+
+        assertEquals(401, response.getStatusCodeValue());
+    }
+
+    @Test
+    void registerCreatesUserWithHashedPassword() {
+        when(passwordEncoder.encode("newpassword")).thenReturn("encoded_newpassword");
+        when(tokenProvider.createToken("newuser", "USER")).thenReturn("fake-jwt-token");
+
+        AuthController.LoginRequest request = new AuthController.LoginRequest();
+        request.setUsername("newuser");
+        request.setPassword("newpassword");
+
+        var response = controller.register(request);
+
+        assertEquals(200, response.getStatusCodeValue());
+        verify(passwordEncoder).encode("newpassword");
+    }
+}


### PR DESCRIPTION
## Fix
Validates password using BCrypt PasswordEncoder before issuing JWT token.

- Store bcrypt-hashed passwords in-memory
- Use passwordEncoder.matches() for login validation
- Hash password on register
- Add AuthControllerTest with 4 test cases

Closes #13