### PR TITLE
fix: use repository query for tag filter instead of full table scan (#14)

### DIFF
--- a/backend/llm-wiki-domain/src/main/java/com/llmwiki/domain/page/repository/PageTagRepository.java
+++ b/backend/llm-wiki-domain/src/main/java/com/llmwiki/domain/page/repository/PageTagRepository.java
@@ -11,4 +11,6 @@ import java.util.UUID;
 @Repository
 public interface PageTagRepository extends JpaRepository<PageTag, PageTagId> {
     List<PageTag> findByPageId(UUID pageId);
+
+    List<PageTag> findByTagIgnoreCase(String tag);
 }

--- a/backend/llm-wiki-service/src/main/java/com/llmwiki/service/search/SearchService.java
+++ b/backend/llm-wiki-service/src/main/java/com/llmwiki/service/search/SearchService.java
@@ -94,9 +94,7 @@ public class SearchService {
             if (request.getTags() != null && !request.getTags().isEmpty()) {
                 Set<UUID> taggedNodeIds = new HashSet<>();
                 for (String tag : request.getTags()) {
-                    List<PageTag> pageTags = pageTagRepo.findAll().stream()
-                            .filter(pt -> pt.getTag().equalsIgnoreCase(tag))
-                            .collect(Collectors.toList());
+                    List<PageTag> pageTags = pageTagRepo.findByTagIgnoreCase(tag);
                     for (PageTag pt : pageTags) {
                         // Find nodes associated with tagged pages
                         pageRepo.findById(pt.getPageId()).ifPresent(page -> {
@@ -146,9 +144,7 @@ public class SearchService {
         List<SearchResult> results = new ArrayList<>();
 
         // Find all pages with the given tag
-        List<PageTag> pageTags = pageTagRepo.findAll().stream()
-                .filter(pt -> pt.getTag().equalsIgnoreCase(tag))
-                .collect(Collectors.toList());
+        List<PageTag> pageTags = pageTagRepo.findByTagIgnoreCase(tag);
 
         for (PageTag pageTag : pageTags) {
             pageRepo.findById(pageTag.getPageId()).ifPresent(page -> {

--- a/backend/llm-wiki-service/src/test/java/com/llmwiki/service/search/SearchServiceTest.java
+++ b/backend/llm-wiki-service/src/test/java/com/llmwiki/service/search/SearchServiceTest.java
@@ -171,6 +171,45 @@ class SearchServiceTest {
     }
 
     @Test
+    void search_shouldFilterByTag() {
+        float[] queryEmbedding = new float[1536];
+        queryEmbedding[0] = 1.0f;
+
+        UUID tagPageId = UUID.randomUUID();
+        KgNode taggedNode = KgNode.builder()
+                .id(nodeId).name("Java").nodeType(NodeType.ENTITY)
+                .description("A programming language").pageId(tagPageId).build();
+        KgNode otherNode = KgNode.builder()
+                .id(UUID.randomUUID()).name("Python").nodeType(NodeType.ENTITY)
+                .description("Another language").build();
+
+        Object[] row1 = {nodeId, 0.3};
+        Object[] row2 = {otherNode.getId(), 0.5};
+
+        PageTag pageTag = PageTag.builder().pageId(tagPageId).tag("jvm").build();
+
+        when(embeddingClient.embed("test")).thenReturn(queryEmbedding);
+        setupVectorSearch(List.of(row1, row2));
+        when(nodeRepo.findById(nodeId)).thenReturn(Optional.of(taggedNode));
+        when(nodeRepo.findById(otherNode.getId())).thenReturn(Optional.of(otherNode));
+        when(pageRepo.findById(tagPageId)).thenReturn(Optional.of(page));
+        when(pageTagRepo.findByTagIgnoreCase("jvm")).thenReturn(List.of(pageTag));
+        when(nodeRepo.findAll()).thenReturn(List.of(taggedNode));
+
+        SearchRequest request = SearchRequest.builder()
+                .query("test")
+                .tags(List.of("jvm"))
+                .limit(10)
+                .build();
+        List<SearchService.SearchResult> results = searchService.search(request);
+
+        assertEquals(1, results.size());
+        assertEquals("Java", results.get(0).nodeName);
+        verify(pageTagRepo).findByTagIgnoreCase("jvm");
+        verify(pageTagRepo, never()).findAll();
+    }
+
+    @Test
     void searchByTag_shouldReturnResultsFromPageTags() {
         UUID tagPageId = UUID.randomUUID();
         PageTag pageTag = PageTag.builder().pageId(tagPageId).tag("java").build();
@@ -181,7 +220,7 @@ class SearchServiceTest {
                 .id(tagPageId).title("Spring Framework").slug("spring")
                 .content("Spring is a framework...").status(PageStatus.APPROVED).build();
 
-        when(pageTagRepo.findAll()).thenReturn(List.of(pageTag));
+        when(pageTagRepo.findByTagIgnoreCase("java")).thenReturn(List.of(pageTag));
         when(pageRepo.findById(tagPageId)).thenReturn(Optional.of(taggedPage));
         when(nodeRepo.findAll()).thenReturn(List.of(taggedNode));
 
@@ -189,17 +228,21 @@ class SearchServiceTest {
 
         assertFalse(results.isEmpty());
         assertEquals("Spring", results.get(0).nodeName);
+        verify(pageTagRepo).findByTagIgnoreCase("java");
+        verify(pageTagRepo, never()).findAll();
     }
 
     @Test
     void searchByTag_shouldFallbackToNameMatch() {
-        when(pageTagRepo.findAll()).thenReturn(Collections.emptyList());
+        when(pageTagRepo.findByTagIgnoreCase("python")).thenReturn(Collections.emptyList());
         when(nodeRepo.findByNameContaining("python")).thenReturn(List.of(node));
 
         List<SearchService.SearchResult> results = searchService.searchByTag("python", 20);
 
         assertFalse(results.isEmpty());
         assertEquals("Java", results.get(0).nodeName);
+        verify(pageTagRepo).findByTagIgnoreCase("python");
+        verify(pageTagRepo, never()).findAll();
     }
 
     @Test


### PR DESCRIPTION
## Problem
`SearchService.search()` and `SearchService.searchByTag()` called `pageTagRepo.findAll()` and streamed the entire `page_tags` table in-memory when filtering by tags. This is O(n) memory and will OOM on large datasets.

## Fix
- Added `List<PageTag> findByTagIgnoreCase(String tag)` to `PageTagRepository` — a Spring Data JPA derived query that filters at the database level
- Replaced `pageTagRepo.findAll().stream().filter(pt -> pt.getTag().equalsIgnoreCase(tag))` with `pageTagRepo.findByTagIgnoreCase(tag)` in both `search()` and `searchByTag()` methods

## Tests
- Updated existing `SearchServiceTest` mocks from `pageTagRepo.findAll()` to `pageTagRepo.findByTagIgnoreCase()`
- Added `search_shouldFilterByTag` test for the `search(SearchRequest)` tag filter path
- Added `verify(pageTagRepo, never()).findAll()` assertions to confirm the full table scan is eliminated
- All 14 tests pass

Closes #14