### PR TITLE
fix: use Jaro-Winkler similarity for duplicate page detection (#16)

### DIFF
--- a/backend/llm-wiki-service/pom.xml
+++ b/backend/llm-wiki-service/pom.xml
@@ -23,5 +23,10 @@
             <groupId>io.github.java-diff-utils</groupId>
             <artifactId>java-diff-utils</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.11.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/backend/llm-wiki-service/src/main/java/com/llmwiki/service/maintenance/DuplicateGroup.java
+++ b/backend/llm-wiki-service/src/main/java/com/llmwiki/service/maintenance/DuplicateGroup.java
@@ -1,0 +1,19 @@
+package com.llmwiki.service.maintenance;
+
+import com.llmwiki.domain.page.entity.Page;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Represents a group of potentially duplicate pages with their similarity score.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DuplicateGroup {
+    private List<Page> pages;
+    private double similarity;
+}

--- a/backend/llm-wiki-service/src/main/java/com/llmwiki/service/maintenance/MaintenanceReport.java
+++ b/backend/llm-wiki-service/src/main/java/com/llmwiki/service/maintenance/MaintenanceReport.java
@@ -19,6 +19,6 @@ public class MaintenanceReport {
     private int contradictionCount;
     private List<Page> orphans;
     private List<Page> stalePages;
-    private List<List<Page>> duplicates;
+    private List<DuplicateGroup> duplicates;
     private List<Page> contradictions;
 }

--- a/backend/llm-wiki-service/src/main/java/com/llmwiki/service/maintenance/MaintenanceService.java
+++ b/backend/llm-wiki-service/src/main/java/com/llmwiki/service/maintenance/MaintenanceService.java
@@ -9,6 +9,7 @@ import com.llmwiki.domain.page.repository.PageRepository;
 import com.llmwiki.domain.processing.repository.ProcessingLogRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.text.similarity.JaroWinklerSimilarity;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -23,6 +24,8 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Slf4j
 public class MaintenanceService {
+
+    private static final double DUPLICATE_THRESHOLD = 0.85;
 
     private final KgNodeRepository kgNodeRepo;
     private final KgEdgeRepository kgEdgeRepo;
@@ -59,18 +62,49 @@ public class MaintenanceService {
     }
 
     /**
-     * 查找可能重复的页面（标题相似）
+     * 查找可能重复的页面（使用Jaro-Winkler相似度）
+     * 相似度超过0.85的页面被归为同一组
      */
-    public List<List<Page>> findDuplicates() {
+    public List<DuplicateGroup> findDuplicates() {
         List<Page> allPages = pageRepo.findAll();
-        Map<String, List<Page>> byTitle = new HashMap<>();
-        for (Page p : allPages) {
-            String key = p.getTitle().toLowerCase().trim();
-            byTitle.computeIfAbsent(key, k -> new ArrayList<>()).add(p);
+        JaroWinklerSimilarity similarity = new JaroWinklerSimilarity();
+
+        // Track which pages have been grouped to avoid duplicates in output
+        Set<UUID> grouped = new HashSet<>();
+        List<DuplicateGroup> result = new ArrayList<>();
+
+        for (int i = 0; i < allPages.size(); i++) {
+            Page pageA = allPages.get(i);
+            if (grouped.contains(pageA.getId())) continue;
+
+            List<Page> group = new ArrayList<>();
+            group.add(pageA);
+            double maxSimilarity = 1.0;
+
+            for (int j = i + 1; j < allPages.size(); j++) {
+                Page pageB = allPages.get(j);
+                if (grouped.contains(pageB.getId())) continue;
+
+                String titleA = pageA.getTitle().toLowerCase().trim();
+                String titleB = pageB.getTitle().toLowerCase().trim();
+
+                Double sim = similarity.apply(titleA, titleB);
+                if (sim != null && sim > DUPLICATE_THRESHOLD) {
+                    group.add(pageB);
+                    grouped.add(pageB.getId());
+                    if (sim < maxSimilarity) {
+                        maxSimilarity = sim;
+                    }
+                }
+            }
+
+            if (group.size() > 1) {
+                grouped.add(pageA.getId());
+                result.add(new DuplicateGroup(group, maxSimilarity));
+            }
         }
-        return byTitle.values().stream()
-                .filter(list -> list.size() > 1)
-                .collect(Collectors.toList());
+
+        return result;
     }
 
     /**
@@ -127,11 +161,12 @@ public class MaintenanceService {
         report.setTotalPages(pageRepo.count());
         report.setOrphanCount(findOrphans().size());
         report.setStaleCount(findStalePages(30).size());
-        report.setDuplicateGroups(findDuplicates().size());
+        List<DuplicateGroup> dupGroups = findDuplicates();
+        report.setDuplicateGroups(dupGroups.size());
         report.setContradictionCount(findContradictions().size());
         report.setOrphans(findOrphans());
         report.setStalePages(findStalePages(30));
-        report.setDuplicates(findDuplicates());
+        report.setDuplicates(dupGroups);
         report.setContradictions(findContradictions());
         return report;
     }

--- a/backend/llm-wiki-service/src/test/java/com/llmwiki/service/maintenance/MaintenanceServiceTest.java
+++ b/backend/llm-wiki-service/src/test/java/com/llmwiki/service/maintenance/MaintenanceServiceTest.java
@@ -118,4 +118,170 @@ class MaintenanceServiceTest {
         // Then - exactly 10000 chars should NOT be suggested for split (must be > 10000)
         assertTrue(result.isEmpty());
     }
+
+    @Test
+    void findDuplicatesShouldDetectExactDuplicates() {
+        // Given - two pages with the same title
+        Page page1 = Page.builder()
+                .id(UUID.randomUUID())
+                .title("Java Guide")
+                .slug("java-guide")
+                .content("Content 1")
+                .build();
+
+        Page page2 = Page.builder()
+                .id(UUID.randomUUID())
+                .title("Java Guide")
+                .slug("java-guide-2")
+                .content("Content 2")
+                .build();
+
+        Page page3 = Page.builder()
+                .id(UUID.randomUUID())
+                .title("Python Tutorial")
+                .slug("python-tutorial")
+                .content("Different content")
+                .build();
+
+        when(pageRepo.findAll()).thenReturn(List.of(page1, page2, page3));
+
+        // When
+        List<DuplicateGroup> result = maintenanceService.findDuplicates();
+
+        // Then - should find one group with the two "Java Guide" pages
+        assertEquals(1, result.size());
+        assertEquals(2, result.get(0).getPages().size());
+        assertEquals(1.0, result.get(0).getSimilarity(), 0.001);
+        List<String> titles = result.get(0).getPages().stream()
+                .map(Page::getTitle)
+                .toList();
+        assertTrue(titles.contains("Java Guide"));
+    }
+
+    @Test
+    void findDuplicatesShouldDetectNearDuplicates() {
+        // Given - titles that are similar but not identical
+        Page page1 = Page.builder()
+                .id(UUID.randomUUID())
+                .title("Java Programming Guide")
+                .slug("java-guide")
+                .content("Content 1")
+                .build();
+
+        Page page2 = Page.builder()
+                .id(UUID.randomUUID())
+                .title("Java Programming Guides")
+                .slug("java-guides")
+                .content("Content 2")
+                .build();
+
+        Page page3 = Page.builder()
+                .id(UUID.randomUUID())
+                .title("Python Tutorial")
+                .slug("python-tutorial")
+                .content("Different content")
+                .build();
+
+        when(pageRepo.findAll()).thenReturn(List.of(page1, page2, page3));
+
+        // When
+        List<DuplicateGroup> result = maintenanceService.findDuplicates();
+
+        // Then - should detect near-duplicate group (Jaro-Winkler > 0.85)
+        assertEquals(1, result.size());
+        assertEquals(2, result.get(0).getPages().size());
+        assertTrue(result.get(0).getSimilarity() > 0.85);
+    }
+
+    @Test
+    void findDuplicatesShouldNotGroupDissimilarTitles() {
+        // Given - pages with very different titles
+        Page page1 = Page.builder()
+                .id(UUID.randomUUID())
+                .title("Java Programming Guide")
+                .slug("java-guide")
+                .content("Content 1")
+                .build();
+
+        Page page2 = Page.builder()
+                .id(UUID.randomUUID())
+                .title("Python Data Science Handbook")
+                .slug("python-handbook")
+                .content("Content 2")
+                .build();
+
+        Page page3 = Page.builder()
+                .id(UUID.randomUUID())
+                .title("React Component Patterns")
+                .slug("react-patterns")
+                .content("Content 3")
+                .build();
+
+        when(pageRepo.findAll()).thenReturn(List.of(page1, page2, page3));
+
+        // When
+        List<DuplicateGroup> result = maintenanceService.findDuplicates();
+
+        // Then - no groups should be found
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void findDuplicatesShouldReturnEmptyForEmptyPageList() {
+        // Given
+        when(pageRepo.findAll()).thenReturn(new ArrayList<>());
+
+        // When
+        List<DuplicateGroup> result = maintenanceService.findDuplicates();
+
+        // Then
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void findDuplicatesShouldReturnEmptyForSinglePage() {
+        // Given - only one page, no duplicates possible
+        Page page = Page.builder()
+                .id(UUID.randomUUID())
+                .title("Solo Page")
+                .slug("solo")
+                .content("Content")
+                .build();
+
+        when(pageRepo.findAll()).thenReturn(List.of(page));
+
+        // When
+        List<DuplicateGroup> result = maintenanceService.findDuplicates();
+
+        // Then
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void findDuplicatesShouldBeCaseInsensitive() {
+        // Given - same title different cases
+        Page page1 = Page.builder()
+                .id(UUID.randomUUID())
+                .title("JAVA GUIDE")
+                .slug("java-guide-1")
+                .content("Content 1")
+                .build();
+
+        Page page2 = Page.builder()
+                .id(UUID.randomUUID())
+                .title("java guide")
+                .slug("java-guide-2")
+                .content("Content 2")
+                .build();
+
+        when(pageRepo.findAll()).thenReturn(List.of(page1, page2));
+
+        // When
+        List<DuplicateGroup> result = maintenanceService.findDuplicates();
+
+        // Then - should detect as duplicates (case-insensitive)
+        assertEquals(1, result.size());
+        assertEquals(2, result.get(0).getPages().size());
+        assertEquals(1.0, result.get(0).getSimilarity(), 0.001);
+    }
 }

--- a/backend/llm-wiki-web/src/main/java/com/llmwiki/web/controller/AdminController.java
+++ b/backend/llm-wiki-web/src/main/java/com/llmwiki/web/controller/AdminController.java
@@ -4,6 +4,7 @@ import com.llmwiki.domain.config.entity.SystemConfig;
 import com.llmwiki.domain.config.repository.SystemConfigRepository;
 import com.llmwiki.service.maintenance.MaintenanceReport;
 import com.llmwiki.service.maintenance.MaintenanceService;
+import com.llmwiki.service.maintenance.DuplicateGroup;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -67,7 +68,7 @@ public class AdminController {
      * 触发重复检测
      */
     @PostMapping("/maintenance/duplicates")
-    public ResponseEntity<List<?>> triggerDuplicateCheck() {
+    public ResponseEntity<List<DuplicateGroup>> triggerDuplicateCheck() {
         return ResponseEntity.ok(maintenanceService.findDuplicates());
     }
 

--- a/backend/llm-wiki-web/src/test/java/com/llmwiki/web/config/MaintenanceSchedulerTest.java
+++ b/backend/llm-wiki-web/src/test/java/com/llmwiki/web/config/MaintenanceSchedulerTest.java
@@ -4,6 +4,7 @@ import com.llmwiki.domain.maintenance.entity.MaintenanceReportLog;
 import com.llmwiki.domain.maintenance.repository.MaintenanceReportLogRepository;
 import com.llmwiki.domain.page.entity.Page;
 import com.llmwiki.service.maintenance.MaintenanceService;
+import com.llmwiki.service.maintenance.DuplicateGroup;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -80,7 +81,7 @@ class MaintenanceSchedulerTest {
         Page dup2 = Page.builder().id(UUID.randomUUID()).title("Dup").slug("dup-2").build();
         Page splitPage = Page.builder().id(UUID.randomUUID()).title("Long Page").slug("long").build();
 
-        when(maintenanceService.findDuplicates()).thenReturn(List.of(List.of(dup1, dup2)));
+        when(maintenanceService.findDuplicates()).thenReturn(List.of(new DuplicateGroup(List.of(dup1, dup2), 1.0)));
         when(maintenanceService.findSplitSuggestions()).thenReturn(List.of(splitPage));
 
         // When


### PR DESCRIPTION
## Summary
Fixes #16 — `MaintenanceService.findDuplicates()` previously only matched exact lowercase titles, missing near-duplicates like "Java Guide" vs "Java Programming Guide".

## Changes
- **Added** Apache Commons Text 1.11.0 dependency (`llm-wiki-service/pom.xml`)
- **Created** `DuplicateGroup` class — holds a list of similar pages + their Jaro-Winkler similarity score
- **Refactored** `MaintenanceService.findDuplicates()` — uses `JaroWinklerSimilarity` with threshold 0.85 instead of exact string match
- **Updated** `MaintenanceReport` — `duplicates` field changed from `List<List<Page>>` to `List<DuplicateGroup>`
- **Updated** `AdminController` — `/api/admin/maintenance/duplicates` now returns `List<DuplicateGroup>`
- **Added tests** (6 new tests):
  - Exact duplicates detected
  - Near-duplicates (similarity > 0.85) detected
  - Dissimilar titles not grouped
  - Case-insensitive matching
  - Empty page list returns empty
  - Single page returns empty
- **Updated** `MaintenanceSchedulerTest` to use new `DuplicateGroup` type

## Verification
All 109 tests pass (61 service + 48 web).

```bash
cd backend && mvn test
```