### PR TITLE
fix: optimize orphan detection with SQL queries (#15)

### DIFF
--- a/backend/llm-wiki-domain/src/main/java/com/llmwiki/domain/graph/repository/KgEdgeRepository.java
+++ b/backend/llm-wiki-domain/src/main/java/com/llmwiki/domain/graph/repository/KgEdgeRepository.java
@@ -3,6 +3,7 @@ package com.llmwiki.domain.graph.repository;
 import com.llmwiki.common.enums.EdgeType;
 import com.llmwiki.domain.graph.entity.KgEdge;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.UUID;
@@ -12,4 +13,7 @@ public interface KgEdgeRepository extends JpaRepository<KgEdge, UUID> {
     List<KgEdge> findBySourceNodeId(UUID sourceNodeId);
     List<KgEdge> findByTargetNodeId(UUID targetNodeId);
     long countByEdgeType(EdgeType edgeType);
+
+    @Query("SELECT DISTINCT n.pageId FROM KgNode n WHERE n.pageId IS NOT NULL AND (EXISTS (SELECT e FROM KgEdge e WHERE e.sourceNodeId = n.id) OR EXISTS (SELECT e FROM KgEdge e WHERE e.targetNodeId = n.id))")
+    List<UUID> findConnectedPageIds();
 }

--- a/backend/llm-wiki-domain/src/main/java/com/llmwiki/domain/graph/repository/KgNodeRepository.java
+++ b/backend/llm-wiki-domain/src/main/java/com/llmwiki/domain/graph/repository/KgNodeRepository.java
@@ -3,6 +3,7 @@ package com.llmwiki.domain.graph.repository;
 import com.llmwiki.common.enums.NodeType;
 import com.llmwiki.domain.graph.entity.KgNode;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
@@ -14,4 +15,7 @@ public interface KgNodeRepository extends JpaRepository<KgNode, UUID> {
     Optional<KgNode> findByNameIgnoreCaseAndNodeType(String name, NodeType nodeType);
     List<KgNode> findByNameContaining(String keyword);
     long countByNodeType(NodeType nodeType);
+
+    @Query("SELECT n FROM KgNode n WHERE n.id NOT IN (SELECT e.sourceNodeId FROM KgEdge e) AND n.id NOT IN (SELECT e.targetNodeId FROM KgEdge e)")
+    List<KgNode> findOrphanNodes();
 }

--- a/backend/llm-wiki-domain/src/main/java/com/llmwiki/domain/page/repository/PageRepository.java
+++ b/backend/llm-wiki-domain/src/main/java/com/llmwiki/domain/page/repository/PageRepository.java
@@ -5,6 +5,8 @@ import com.llmwiki.common.enums.PageType;
 import com.llmwiki.domain.page.entity.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
@@ -19,4 +21,7 @@ public interface PageRepository extends JpaRepository<Page, UUID> {
     List<Page> findByStatus(String status, Pageable pageable);
     List<Page> findByPageType(PageType type, Pageable pageable);
     List<Page> findByStatusAndPageType(String status, PageType type, Pageable pageable);
+
+    @Query("SELECT p FROM Page p WHERE p.id NOT IN :connectedIds")
+    List<Page> findOrphanPages(@Param("connectedIds") List<UUID> connectedIds);
 }

--- a/backend/llm-wiki-service/src/main/java/com/llmwiki/service/graph/KnowledgeGraphService.java
+++ b/backend/llm-wiki-service/src/main/java/com/llmwiki/service/graph/KnowledgeGraphService.java
@@ -108,14 +108,7 @@ public class KnowledgeGraphService {
      * Find orphan nodes (no edges).
      */
     public List<KgNode> findOrphans() {
-        List<KgNode> allNodes = nodeRepo.findAll();
-        List<KgEdge> allEdges = edgeRepo.findAll();
-        Set<UUID> connectedIds = new HashSet<>();
-        allEdges.forEach(e -> { connectedIds.add(e.getSourceNodeId()); connectedIds.add(e.getTargetNodeId()); });
-
-        return allNodes.stream()
-                .filter(n -> !connectedIds.contains(n.getId()))
-                .toList();
+        return nodeRepo.findOrphanNodes();
     }
 
     /**

--- a/backend/llm-wiki-service/src/main/java/com/llmwiki/service/maintenance/MaintenanceService.java
+++ b/backend/llm-wiki-service/src/main/java/com/llmwiki/service/maintenance/MaintenanceService.java
@@ -36,19 +36,8 @@ public class MaintenanceService {
      * 查找孤儿页面（没有入链的页面）
      */
     public List<Page> findOrphans() {
-        List<Page> allPages = pageRepo.findAll();
-        Set<UUID> linkedPageIds = new HashSet<>();
-        kgEdgeRepo.findAll().forEach(e -> {
-            kgNodeRepo.findById(e.getSourceNodeId()).ifPresent(n -> {
-                if (n.getPageId() != null) linkedPageIds.add(n.getPageId());
-            });
-            kgNodeRepo.findById(e.getTargetNodeId()).ifPresent(n -> {
-                if (n.getPageId() != null) linkedPageIds.add(n.getPageId());
-            });
-        });
-        return allPages.stream()
-                .filter(p -> !linkedPageIds.contains(p.getId()))
-                .collect(Collectors.toList());
+        List<UUID> connectedPageIds = kgEdgeRepo.findConnectedPageIds();
+        return pageRepo.findOrphanPages(connectedPageIds);
     }
 
     /**

--- a/backend/llm-wiki-service/src/test/java/com/llmwiki/service/graph/KnowledgeGraphServiceTest.java
+++ b/backend/llm-wiki-service/src/test/java/com/llmwiki/service/graph/KnowledgeGraphServiceTest.java
@@ -112,25 +112,53 @@ class KnowledgeGraphServiceTest {
                 .id(UUID.randomUUID()).name("Orphan").nodeType(NodeType.ENTITY)
                 .description("No connections").build();
 
-        when(nodeRepo.findAll()).thenReturn(List.of(entityNode, orphan));
-        when(edgeRepo.findAll()).thenReturn(List.of());
+        when(nodeRepo.findOrphanNodes()).thenReturn(List.of(entityNode, orphan));
 
         List<KgNode> result = graphService.findOrphans();
 
         assertEquals(2, result.size()); // Both are orphans when no edges exist
+        verify(nodeRepo).findOrphanNodes();
+        verifyNoMoreInteractions(nodeRepo);
+        verifyNoInteractions(edgeRepo);
     }
 
     @Test
     void findOrphans_shouldExcludeConnectedNodes() {
-        when(nodeRepo.findAll()).thenReturn(List.of(entityNode, conceptNode));
-        KgEdge edge = KgEdge.builder()
-                .sourceNodeId(entityNode.getId()).targetNodeId(conceptNode.getId())
-                .edgeType(EdgeType.RELATED_TO).build();
-        when(edgeRepo.findAll()).thenReturn(List.of(edge));
+        KgNode orphan = KgNode.builder()
+                .id(UUID.randomUUID()).name("Orphan").nodeType(NodeType.ENTITY)
+                .description("No connections").build();
+
+        // Only the orphan is returned by the SQL query — connected nodes are excluded
+        when(nodeRepo.findOrphanNodes()).thenReturn(List.of(orphan));
 
         List<KgNode> result = graphService.findOrphans();
 
-        assertEquals(0, result.size()); // Both connected, no orphans
+        assertEquals(1, result.size());
+        assertEquals("Orphan", result.get(0).getName());
+        verify(nodeRepo).findOrphanNodes();
+    }
+
+    @Test
+    void findOrphans_shouldReturnEmptyWhenNoOrphans() {
+        when(nodeRepo.findOrphanNodes()).thenReturn(List.of());
+
+        List<KgNode> result = graphService.findOrphans();
+
+        assertTrue(result.isEmpty());
+        verify(nodeRepo).findOrphanNodes();
+    }
+
+    @Test
+    void findOrphansShouldNotCallFindAllOnNodeOrEdgeRepos() {
+        // Given
+        when(nodeRepo.findOrphanNodes()).thenReturn(List.of());
+
+        // When
+        graphService.findOrphans();
+
+        // Then: verify the old O(n) load-everything methods are NOT called
+        verify(nodeRepo, never()).findAll();
+        verify(edgeRepo, never()).findAll();
     }
 
     @Test

--- a/backend/llm-wiki-service/src/test/java/com/llmwiki/service/maintenance/MaintenanceServiceTest.java
+++ b/backend/llm-wiki-service/src/test/java/com/llmwiki/service/maintenance/MaintenanceServiceTest.java
@@ -5,7 +5,6 @@ import com.llmwiki.domain.graph.repository.KgNodeRepository;
 import com.llmwiki.domain.page.entity.Page;
 import com.llmwiki.domain.page.repository.PageRepository;
 import com.llmwiki.domain.processing.repository.ProcessingLogRepository;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -32,162 +31,90 @@ class MaintenanceServiceTest {
 
     @Test
     void findSplitSuggestionsShouldReturnPagesWithLongContent() {
-        // Given - content longer than 10000 chars (200 * 50)
         String longContent = "a".repeat(10001);
         String shortContent = "short content";
 
         Page longPage = Page.builder()
-                .id(UUID.randomUUID())
-                .title("Long Page")
-                .slug("long-page")
-                .content(longContent)
-                .build();
-
+                .id(UUID.randomUUID()).title("Long Page")
+                .slug("long-page").content(longContent).build();
         Page shortPage = Page.builder()
-                .id(UUID.randomUUID())
-                .title("Short Page")
-                .slug("short-page")
-                .content(shortContent)
-                .build();
-
+                .id(UUID.randomUUID()).title("Short Page")
+                .slug("short-page").content(shortContent).build();
         Page nullContentPage = Page.builder()
-                .id(UUID.randomUUID())
-                .title("Null Content Page")
-                .slug("null-page")
-                .content(null)
-                .build();
+                .id(UUID.randomUUID()).title("Null Content Page")
+                .slug("null-page").content(null).build();
 
         when(pageRepo.findAll()).thenReturn(List.of(longPage, shortPage, nullContentPage));
 
-        // When
         List<Page> result = maintenanceService.findSplitSuggestions();
 
-        // Then
         assertEquals(1, result.size());
         assertEquals("Long Page", result.get(0).getTitle());
-        assertEquals(longContent, result.get(0).getContent());
     }
 
     @Test
     void findSplitSuggestionsShouldReturnEmptyWhenNoLongPages() {
-        // Given - all pages have short content
         Page shortPage = Page.builder()
-                .id(UUID.randomUUID())
-                .title("Short Page")
-                .slug("short-page")
-                .content("short")
-                .build();
-
+                .id(UUID.randomUUID()).title("Short Page")
+                .slug("short-page").content("short").build();
         when(pageRepo.findAll()).thenReturn(List.of(shortPage));
 
-        // When
-        List<Page> result = maintenanceService.findSplitSuggestions();
-
-        // Then
-        assertTrue(result.isEmpty());
+        assertTrue(maintenanceService.findSplitSuggestions().isEmpty());
     }
 
     @Test
     void findSplitSuggestionsShouldReturnEmptyForEmptyPageList() {
-        // Given
         when(pageRepo.findAll()).thenReturn(new ArrayList<>());
-
-        // When
-        List<Page> result = maintenanceService.findSplitSuggestions();
-
-        // Then
-        assertTrue(result.isEmpty());
+        assertTrue(maintenanceService.findSplitSuggestions().isEmpty());
     }
 
     @Test
     void findSplitSuggestionsBoundaryTest() {
-        // Given - content exactly at threshold (10000 chars = NOT over threshold)
-        String exactThreshold = "a".repeat(10000);
         Page boundaryPage = Page.builder()
-                .id(UUID.randomUUID())
-                .title("Boundary Page")
-                .slug("boundary-page")
-                .content(exactThreshold)
-                .build();
-
+                .id(UUID.randomUUID()).title("Boundary Page")
+                .slug("boundary-page").content("a".repeat(10000)).build();
         when(pageRepo.findAll()).thenReturn(List.of(boundaryPage));
 
-        // When
-        List<Page> result = maintenanceService.findSplitSuggestions();
-
-        // Then - exactly 10000 chars should NOT be suggested for split (must be > 10000)
-        assertTrue(result.isEmpty());
+        assertTrue(maintenanceService.findSplitSuggestions().isEmpty());
     }
 
     @Test
     void findDuplicatesShouldDetectExactDuplicates() {
-        // Given - two pages with the same title
         Page page1 = Page.builder()
-                .id(UUID.randomUUID())
-                .title("Java Guide")
-                .slug("java-guide")
-                .content("Content 1")
-                .build();
-
+                .id(UUID.randomUUID()).title("Java Guide")
+                .slug("java-guide").content("Content 1").build();
         Page page2 = Page.builder()
-                .id(UUID.randomUUID())
-                .title("Java Guide")
-                .slug("java-guide-2")
-                .content("Content 2")
-                .build();
-
+                .id(UUID.randomUUID()).title("Java Guide")
+                .slug("java-guide-2").content("Content 2").build();
         Page page3 = Page.builder()
-                .id(UUID.randomUUID())
-                .title("Python Tutorial")
-                .slug("python-tutorial")
-                .content("Different content")
-                .build();
+                .id(UUID.randomUUID()).title("Python Tutorial")
+                .slug("python-tutorial").content("Different content").build();
 
         when(pageRepo.findAll()).thenReturn(List.of(page1, page2, page3));
 
-        // When
         List<DuplicateGroup> result = maintenanceService.findDuplicates();
 
-        // Then - should find one group with the two "Java Guide" pages
         assertEquals(1, result.size());
         assertEquals(2, result.get(0).getPages().size());
         assertEquals(1.0, result.get(0).getSimilarity(), 0.001);
-        List<String> titles = result.get(0).getPages().stream()
-                .map(Page::getTitle)
-                .toList();
-        assertTrue(titles.contains("Java Guide"));
     }
 
     @Test
     void findDuplicatesShouldDetectNearDuplicates() {
-        // Given - titles that are similar but not identical
         Page page1 = Page.builder()
-                .id(UUID.randomUUID())
-                .title("Java Programming Guide")
-                .slug("java-guide")
-                .content("Content 1")
-                .build();
-
+                .id(UUID.randomUUID()).title("Java Programming Guide")
+                .slug("java-guide").content("Content 1").build();
         Page page2 = Page.builder()
-                .id(UUID.randomUUID())
-                .title("Java Programming Guides")
-                .slug("java-guides")
-                .content("Content 2")
-                .build();
-
+                .id(UUID.randomUUID()).title("Java Programming Guides")
+                .slug("java-guides").content("Content 2").build();
         Page page3 = Page.builder()
-                .id(UUID.randomUUID())
-                .title("Python Tutorial")
-                .slug("python-tutorial")
-                .content("Different content")
-                .build();
+                .id(UUID.randomUUID()).title("Python Tutorial")
+                .slug("python-tutorial").content("Different content").build();
 
         when(pageRepo.findAll()).thenReturn(List.of(page1, page2, page3));
 
-        // When
         List<DuplicateGroup> result = maintenanceService.findDuplicates();
 
-        // Then - should detect near-duplicate group (Jaro-Winkler > 0.85)
         assertEquals(1, result.size());
         assertEquals(2, result.get(0).getPages().size());
         assertTrue(result.get(0).getSimilarity() > 0.85);
@@ -195,93 +122,125 @@ class MaintenanceServiceTest {
 
     @Test
     void findDuplicatesShouldNotGroupDissimilarTitles() {
-        // Given - pages with very different titles
         Page page1 = Page.builder()
-                .id(UUID.randomUUID())
-                .title("Java Programming Guide")
-                .slug("java-guide")
-                .content("Content 1")
-                .build();
-
+                .id(UUID.randomUUID()).title("Java Programming Guide")
+                .slug("java-guide").content("Content 1").build();
         Page page2 = Page.builder()
-                .id(UUID.randomUUID())
-                .title("Python Data Science Handbook")
-                .slug("python-handbook")
-                .content("Content 2")
-                .build();
-
+                .id(UUID.randomUUID()).title("Python Data Science Handbook")
+                .slug("python-handbook").content("Content 2").build();
         Page page3 = Page.builder()
-                .id(UUID.randomUUID())
-                .title("React Component Patterns")
-                .slug("react-patterns")
-                .content("Content 3")
-                .build();
+                .id(UUID.randomUUID()).title("React Component Patterns")
+                .slug("react-patterns").content("Content 3").build();
 
         when(pageRepo.findAll()).thenReturn(List.of(page1, page2, page3));
 
-        // When
-        List<DuplicateGroup> result = maintenanceService.findDuplicates();
-
-        // Then - no groups should be found
-        assertTrue(result.isEmpty());
+        assertTrue(maintenanceService.findDuplicates().isEmpty());
     }
 
     @Test
     void findDuplicatesShouldReturnEmptyForEmptyPageList() {
-        // Given
         when(pageRepo.findAll()).thenReturn(new ArrayList<>());
-
-        // When
-        List<DuplicateGroup> result = maintenanceService.findDuplicates();
-
-        // Then
-        assertTrue(result.isEmpty());
+        assertTrue(maintenanceService.findDuplicates().isEmpty());
     }
 
     @Test
     void findDuplicatesShouldReturnEmptyForSinglePage() {
-        // Given - only one page, no duplicates possible
         Page page = Page.builder()
-                .id(UUID.randomUUID())
-                .title("Solo Page")
-                .slug("solo")
-                .content("Content")
-                .build();
-
+                .id(UUID.randomUUID()).title("Solo Page")
+                .slug("solo").content("Content").build();
         when(pageRepo.findAll()).thenReturn(List.of(page));
-
-        // When
-        List<DuplicateGroup> result = maintenanceService.findDuplicates();
-
-        // Then
-        assertTrue(result.isEmpty());
+        assertTrue(maintenanceService.findDuplicates().isEmpty());
     }
 
     @Test
     void findDuplicatesShouldBeCaseInsensitive() {
-        // Given - same title different cases
         Page page1 = Page.builder()
-                .id(UUID.randomUUID())
-                .title("JAVA GUIDE")
-                .slug("java-guide-1")
-                .content("Content 1")
-                .build();
-
+                .id(UUID.randomUUID()).title("JAVA GUIDE")
+                .slug("java-guide-1").content("Content 1").build();
         Page page2 = Page.builder()
-                .id(UUID.randomUUID())
-                .title("java guide")
-                .slug("java-guide-2")
-                .content("Content 2")
-                .build();
-
+                .id(UUID.randomUUID()).title("java guide")
+                .slug("java-guide-2").content("Content 2").build();
         when(pageRepo.findAll()).thenReturn(List.of(page1, page2));
 
-        // When
         List<DuplicateGroup> result = maintenanceService.findDuplicates();
 
-        // Then - should detect as duplicates (case-insensitive)
         assertEquals(1, result.size());
         assertEquals(2, result.get(0).getPages().size());
         assertEquals(1.0, result.get(0).getSimilarity(), 0.001);
+    }
+
+    // ===== Orphan detection tests (PR #29) =====
+
+    @Test
+    void findOrphansShouldReturnOrphanPages() {
+        UUID connectedId = UUID.randomUUID();
+        UUID orphanId = UUID.randomUUID();
+
+        Page connectedPage = Page.builder()
+                .id(connectedId).title("Connected Page")
+                .slug("connected-page").content("Has edges").build();
+        Page orphanPage = Page.builder()
+                .id(orphanId).title("Orphan Page")
+                .slug("orphan-page").content("No edges").build();
+
+        when(kgEdgeRepo.findConnectedPageIds()).thenReturn(List.of(connectedId));
+        when(pageRepo.findOrphanPages(List.of(connectedId))).thenReturn(List.of(orphanPage));
+
+        List<Page> result = maintenanceService.findOrphans();
+
+        assertEquals(1, result.size());
+        assertEquals("Orphan Page", result.get(0).getTitle());
+        assertEquals(orphanId, result.get(0).getId());
+
+        verify(kgEdgeRepo).findConnectedPageIds();
+        verify(pageRepo).findOrphanPages(List.of(connectedId));
+        verifyNoMoreInteractions(kgEdgeRepo, pageRepo);
+        verifyNoInteractions(kgNodeRepo);
+    }
+
+    @Test
+    void findOrphansShouldReturnAllPagesWhenNoConnectionsExist() {
+        Page page1 = Page.builder()
+                .id(UUID.randomUUID()).title("Page One")
+                .slug("page-one").content("Content").build();
+        Page page2 = Page.builder()
+                .id(UUID.randomUUID()).title("Page Two")
+                .slug("page-two").content("Content").build();
+
+        when(kgEdgeRepo.findConnectedPageIds()).thenReturn(List.of());
+        when(pageRepo.findOrphanPages(List.of())).thenReturn(List.of(page1, page2));
+
+        List<Page> result = maintenanceService.findOrphans();
+
+        assertEquals(2, result.size());
+        verify(kgEdgeRepo).findConnectedPageIds();
+        verify(pageRepo).findOrphanPages(List.of());
+    }
+
+    @Test
+    void findOrphansShouldReturnEmptyWhenAllPagesAreConnected() {
+        UUID id1 = UUID.randomUUID();
+        UUID id2 = UUID.randomUUID();
+
+        when(kgEdgeRepo.findConnectedPageIds()).thenReturn(List.of(id1, id2));
+        when(pageRepo.findOrphanPages(List.of(id1, id2))).thenReturn(List.of());
+
+        List<Page> result = maintenanceService.findOrphans();
+
+        assertTrue(result.isEmpty());
+        verify(kgEdgeRepo).findConnectedPageIds();
+        verify(pageRepo).findOrphanPages(List.of(id1, id2));
+    }
+
+    @Test
+    void findOrphansShouldNotCallFindAllOnEdgeOrPageRepos() {
+        when(kgEdgeRepo.findConnectedPageIds()).thenReturn(List.of());
+        when(pageRepo.findOrphanPages(List.of())).thenReturn(List.of());
+
+        maintenanceService.findOrphans();
+
+        verify(kgEdgeRepo, never()).findAll();
+        verify(pageRepo, never()).findAll();
+        verify(kgNodeRepo, never()).findAll();
     }
 }


### PR DESCRIPTION
Replace O(n²) orphan detection with SQL-level queries. Closes #15