### PR TITLE
fix: graph expand, diffviewer split mode, sync scheduler filter (#20 #21 #22)

### DIFF
--- a/backend/llm-wiki-web/src/main/java/com/llmwiki/web/config/SyncScheduler.java
+++ b/backend/llm-wiki-web/src/main/java/com/llmwiki/web/config/SyncScheduler.java
@@ -24,7 +24,7 @@ public class SyncScheduler {
     @Scheduled(cron = "${sync.default-cron:0 */6 * * * *}")
     public void scheduledSync() {
         log.info("Starting scheduled sync");
-        sourceRepo.findAll().forEach(source -> {
+        sourceRepo.findByEnabledTrue().forEach(source -> {
             try {
                 syncService.syncSource(source.getId());
             } catch (Exception e) {

--- a/backend/llm-wiki-web/src/test/java/com/llmwiki/web/config/SyncSchedulerTest.java
+++ b/backend/llm-wiki-web/src/test/java/com/llmwiki/web/config/SyncSchedulerTest.java
@@ -1,0 +1,51 @@
+package com.llmwiki.web.config;
+
+import com.llmwiki.domain.sync.entity.WikiSource;
+import com.llmwiki.domain.sync.repository.WikiSourceRepository;
+import com.llmwiki.service.sync.SyncService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SyncSchedulerTest {
+
+    @Mock SyncService syncService;
+    @Mock WikiSourceRepository sourceRepo;
+
+    @InjectMocks
+    SyncScheduler syncScheduler;
+
+    @Test
+    void scheduledSync_shouldOnlySyncEnabledSources() {
+        WikiSource enabled = WikiSource.builder()
+                .id(UUID.randomUUID()).name("Enabled Source")
+                .adapterClass("test").enabled(true).build();
+        WikiSource disabled = WikiSource.builder()
+                .id(UUID.randomUUID()).name("Disabled Source")
+                .adapterClass("test").enabled(false).build();
+
+        when(sourceRepo.findByEnabledTrue()).thenReturn(List.of(enabled));
+
+        syncScheduler.scheduledSync();
+
+        verify(syncService).syncSource(enabled.getId());
+        verify(syncService, never()).syncSource(disabled.getId());
+    }
+
+    @Test
+    void scheduledSync_shouldHandleEmptySources() {
+        when(sourceRepo.findByEnabledTrue()).thenReturn(List.of());
+
+        syncScheduler.scheduledSync();
+
+        verifyNoInteractions(syncService);
+    }
+}

--- a/frontend/src/components/DiffViewer.tsx
+++ b/frontend/src/components/DiffViewer.tsx
@@ -28,6 +28,22 @@ export default function DiffViewer({ before, after, mode = 'unified' }: DiffView
     const afterLines = (after || '').split('\n');
     const result: DiffLine[] = [];
 
+    // Guard: if total lines > 500, use simple line-by-line comparison instead of O(n*m) LCS
+    if (beforeLines.length + afterLines.length > 500) {
+      const maxLen = Math.max(beforeLines.length, afterLines.length);
+      for (let i = 0; i < maxLen; i++) {
+        const bLine = i < beforeLines.length ? beforeLines[i] : null;
+        const aLine = i < afterLines.length ? afterLines[i] : null;
+        if (bLine === aLine) {
+          if (bLine !== null) result.push({ type: 'unchanged', content: bLine, oldLineNum: i + 1, newLineNum: i + 1 });
+        } else {
+          if (bLine !== null) result.push({ type: 'removed', content: bLine, oldLineNum: i + 1 });
+          if (aLine !== null) result.push({ type: 'added', content: aLine, newLineNum: i + 1 });
+        }
+      }
+      return result;
+    }
+
     // Simple LCS-based diff
     const m = beforeLines.length;
     const n = afterLines.length;
@@ -119,10 +135,13 @@ export default function DiffViewer({ before, after, mode = 'unified' }: DiffView
     );
   }
 
-  // Split mode
-  const removedLines = lines.filter(l => l.type === 'removed');
-  const addedLines = lines.filter(l => l.type === 'added');
-  const maxLen = Math.max(removedLines.length, addedLines.length);
+  // Split mode: show full before/after content side by side with highlighting
+  const beforeLines = (before || '').split('\n');
+  const afterLines = (after || '').split('\n');
+  // Build a set of removed/added line content for quick lookup
+  const removedSet = new Set(lines.filter(l => l.type === 'removed').map(l => l.content));
+  const addedSet = new Set(lines.filter(l => l.type === 'added').map(l => l.content));
+  const maxLen = Math.max(beforeLines.length, afterLines.length);
 
   return (
     <div style={{ display: 'flex', gap: 16, fontFamily: 'monospace', fontSize: 13 }}>
@@ -131,14 +150,11 @@ export default function DiffViewer({ before, after, mode = 'unified' }: DiffView
           <Tag color="red">变更前</Tag>
         </div>
         <div style={{ maxHeight: 500, overflow: 'auto' }}>
-          {Array.from({ length: maxLen }).map((_, idx) => {
-            const line = removedLines[idx];
-            return (
-              <div key={idx} style={{ padding: '2px 8px', background: line ? '#fff1f0' : '#fff', borderBottom: '1px solid #f0f0f0', minHeight: 24 }}>
-                {line?.content || '\u00A0'}
-              </div>
-            );
-          })}
+          {beforeLines.map((content, idx) => (
+            <div key={idx} style={{ padding: '2px 8px', background: removedSet.has(content) ? '#fff1f0' : '#fff', borderBottom: '1px solid #f0f0f0', minHeight: 24 }}>
+              {content || '\u00A0'}
+            </div>
+          ))}
         </div>
       </div>
       <div style={{ flex: 1, border: '1px solid #b7eb8f', borderRadius: 6, overflow: 'hidden' }}>
@@ -146,14 +162,11 @@ export default function DiffViewer({ before, after, mode = 'unified' }: DiffView
           <Tag color="green">变更后</Tag>
         </div>
         <div style={{ maxHeight: 500, overflow: 'auto' }}>
-          {Array.from({ length: maxLen }).map((_, idx) => {
-            const line = addedLines[idx];
-            return (
-              <div key={idx} style={{ padding: '2px 8px', background: line ? '#f6ffed' : '#fff', borderBottom: '1px solid #f0f0f0', minHeight: 24 }}>
-                {line?.content || '\u00A0'}
-              </div>
-            );
-          })}
+          {afterLines.map((content, idx) => (
+            <div key={idx} style={{ padding: '2px 8px', background: addedSet.has(content) ? '#f6ffed' : '#fff', borderBottom: '1px solid #f0f0f0', minHeight: 24 }}>
+              {content || '\u00A0'}
+            </div>
+          ))}
         </div>
       </div>
     </div>

--- a/frontend/src/pages/Graph.tsx
+++ b/frontend/src/pages/Graph.tsx
@@ -188,12 +188,41 @@ export default function Graph() {
       {/* Node detail drawer */}
       <Drawer title="节点详情" open={!!selectedNode} onClose={() => setSelectedNode(null)} width={400}>
         {selectedNode && (
-          <Descriptions column={1} size="small">
-            <Descriptions.Item label="名称">{selectedNode.name}</Descriptions.Item>
-            <Descriptions.Item label="类型"><Tag color={NODE_COLORS[selectedNode.type]}>{selectedNode.type}</Tag></Descriptions.Item>
-            <Descriptions.Item label="ID">{selectedNode.id}</Descriptions.Item>
-            <Descriptions.Item label="描述">{selectedNode.description || '无'}</Descriptions.Item>
-          </Descriptions>
+          <>
+            <Descriptions column={1} size="small">
+              <Descriptions.Item label="名称">{selectedNode.name}</Descriptions.Item>
+              <Descriptions.Item label="类型"><Tag color={NODE_COLORS[selectedNode.type]}>{selectedNode.type}</Tag></Descriptions.Item>
+              <Descriptions.Item label="ID">{selectedNode.id}</Descriptions.Item>
+              <Descriptions.Item label="描述">{selectedNode.description || '无'}</Descriptions.Item>
+            </Descriptions>
+            <Button
+              type="primary"
+              style={{ marginTop: 16 }}
+              onClick={async () => {
+                if (!selectedNode) return;
+                try {
+                  const res = await fetch(`/api/graph/neighborhood/${selectedNode.id}`);
+                  const data = await res.json();
+                  const newNodes = data.nodes.filter((n: any) => !graphData.nodes.some((gn: any) => gn.id === n.id));
+                  const newLinks = data.edges.filter((e: any) => !graphData.links.some((gl: any) => gl.source === e.source && gl.target === e.target));
+                  setGraphData(prev => ({
+                    nodes: [...prev.nodes, ...newNodes],
+                    links: [...prev.links, ...newLinks],
+                  }));
+                  if (newNodes.length > 0) {
+                    message.success(`展开成功，新增 ${newNodes.length} 个节点`);
+                  } else {
+                    message.info('没有更多相邻节点');
+                  }
+                } catch (e) {
+                  message.error('展开失败');
+                }
+                setSelectedNode(null);
+              }}
+            >
+              展开相邻节点
+            </Button>
+          </>
         )}
       </Drawer>
 


### PR DESCRIPTION
## Changes
- **Graph.tsx**: expand button fetches neighborhood and merges into graph (#20)
- **DiffViewer.tsx**: split mode shows full content with line highlighting (#21)
- **DiffViewer.tsx**: LCS guard for >500 lines uses simple comparison (#21)
- **SyncScheduler**: use `findByEnabledTrue()` instead of `findAll()` (#22)
- **SyncSchedulerTest**: verifies disabled sources are skipped

## Test Results
- Full suite: all modules ✅