### PR TITLE
feat: Add FloatArrayToJsonConverter for KgVector JPA entity (#76)

### DIFF
--- a/backend/llm-wiki-domain/src/main/java/com/llmwiki/domain/graph/converter/FloatArrayToJsonConverter.java
+++ b/backend/llm-wiki-domain/src/main/java/com/llmwiki/domain/graph/converter/FloatArrayToJsonConverter.java
@@ -1,0 +1,63 @@
+package com.llmwiki.domain.graph.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * JPA AttributeConverter for converting float[] to/from JSON string.
+ * MariaDB VECTOR type stores vectors as JSON arrays, so this converter
+ * handles the serialization/deserialization of float arrays for JPA entities.
+ */
+@Converter
+public class FloatArrayToJsonConverter implements AttributeConverter<float[], String> {
+
+    private static final String OPEN_BRACKET = "[";
+    private static final String CLOSE_BRACKET = "]";
+    private static final String DELIMITER = ",";
+
+    @Override
+    public String convertToDatabaseColumn(float[] attribute) {
+        if (attribute == null || attribute.length == 0) {
+            return OPEN_BRACKET + CLOSE_BRACKET;
+        }
+        
+        StringBuilder sb = new StringBuilder(OPEN_BRACKET);
+        for (int i = 0; i < attribute.length; i++) {
+            sb.append(attribute[i]);
+            if (i < attribute.length - 1) {
+                sb.append(DELIMITER);
+            }
+        }
+        sb.append(CLOSE_BRACKET);
+        return sb.toString();
+    }
+
+    @Override
+    public float[] convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isEmpty() || 
+            dbData.equals(OPEN_BRACKET + CLOSE_BRACKET)) {
+            return new float[0];
+        }
+        
+        String trimmed = dbData.trim();
+        if (!trimmed.startsWith(OPEN_BRACKET) || !trimmed.endsWith(CLOSE_BRACKET)) {
+            throw new IllegalArgumentException("Invalid JSON array format: " + dbData);
+        }
+        
+        String content = trimmed.substring(1, trimmed.length() - 1).trim();
+        if (content.isEmpty()) {
+            return new float[0];
+        }
+        
+        String[] parts = content.split(DELIMITER);
+        float[] result = new float[parts.length];
+        for (int i = 0; i < parts.length; i++) {
+            result[i] = Float.parseFloat(parts[i].trim());
+        }
+        return result;
+    }
+}

--- a/backend/llm-wiki-domain/src/main/java/com/llmwiki/domain/graph/entity/KgVector.java
+++ b/backend/llm-wiki-domain/src/main/java/com/llmwiki/domain/graph/entity/KgVector.java
@@ -1,5 +1,6 @@
 package com.llmwiki.domain.graph.entity;
 
+import com.llmwiki.domain.graph.converter.FloatArrayToJsonConverter;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -13,6 +14,7 @@ public class KgVector {
     @Id
     private UUID nodeId;
 
+    @Convert(converter = FloatArrayToJsonConverter.class)
     @Column(nullable = false, columnDefinition = "VECTOR(1536)")
     private float[] vector;
 

--- a/backend/llm-wiki-domain/src/test/java/com/llmwiki/domain/graph/converter/FloatArrayToJsonConverterTest.java
+++ b/backend/llm-wiki-domain/src/test/java/com/llmwiki/domain/graph/converter/FloatArrayToJsonConverterTest.java
@@ -1,0 +1,113 @@
+package com.llmwiki.domain.graph.converter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FloatArrayToJsonConverterTest {
+
+    private FloatArrayToJsonConverter converter;
+
+    @BeforeEach
+    void setUp() {
+        converter = new FloatArrayToJsonConverter();
+    }
+
+    @Test
+    void shouldConvertFloatArrayToJsonString() {
+        float[] input = {0.1f, 0.2f, 0.3f};
+        String result = converter.convertToDatabaseColumn(input);
+        assertEquals("[0.1,0.2,0.3]", result);
+    }
+
+    @Test
+    void shouldConvertJsonStringToFloatArray() {
+        String input = "[0.1,0.2,0.3]";
+        float[] result = converter.convertToEntityAttribute(input);
+        assertEquals(3, result.length);
+        assertEquals(0.1f, result[0], 0.0001f);
+        assertEquals(0.2f, result[1], 0.0001f);
+        assertEquals(0.3f, result[2], 0.0001f);
+    }
+
+    @Test
+    void shouldHandleNullInput() {
+        String result = converter.convertToDatabaseColumn(null);
+        assertEquals("[]", result);
+        
+        float[] arrayResult = converter.convertToEntityAttribute(null);
+        assertEquals(0, arrayResult.length);
+    }
+
+    @Test
+    void shouldHandleEmptyArray() {
+        float[] empty = new float[0];
+        String result = converter.convertToDatabaseColumn(empty);
+        assertEquals("[]", result);
+    }
+
+    @Test
+    void shouldHandleEmptyJsonString() {
+        float[] result = converter.convertToEntityAttribute("");
+        assertEquals(0, result.length);
+    }
+
+    @Test
+    void shouldHandleEmptyJsonArray() {
+        float[] result = converter.convertToEntityAttribute("[]");
+        assertEquals(0, result.length);
+    }
+
+    @Test
+    void shouldHandleSingleElement() {
+        float[] toDb = {1.5f};
+        String json = converter.convertToDatabaseColumn(toDb);
+        assertEquals("[1.5]", json);
+        
+        float[] fromDb = converter.convertToEntityAttribute(json);
+        assertEquals(1, fromDb.length);
+        assertEquals(1.5f, fromDb[0], 0.0001f);
+    }
+
+    @Test
+    void shouldRoundTrip() {
+        float[] original = {0.1f, 0.25f, 0.333f, 0.5f, 1.0f};
+        String json = converter.convertToDatabaseColumn(original);
+        float[] result = converter.convertToEntityAttribute(json);
+        
+        assertArrayEquals(original, result, 0.0001f);
+    }
+
+    @Test
+    void shouldThrowOnInvalidJson() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            converter.convertToEntityAttribute("not-a-json-array");
+        });
+    }
+
+    @Test
+    void shouldHandleNegativeValues() {
+        float[] negative = {-1.5f, 0.0f, 1.5f};
+        String json = converter.convertToDatabaseColumn(negative);
+        assertEquals("[-1.5,0.0,1.5]", json);
+        
+        float[] result = converter.convertToEntityAttribute(json);
+        assertArrayEquals(negative, result, 0.0001f);
+    }
+
+    @Test
+    void shouldHandleLargeVectors() {
+        float[] large = new float[1536];
+        for (int i = 0; i < 1536; i++) {
+            large[i] = (float) (i * 0.001);
+        }
+        
+        String json = converter.convertToDatabaseColumn(large);
+        float[] result = converter.convertToEntityAttribute(json);
+        
+        assertEquals(1536, result.length);
+        assertEquals(0.0f, result[0], 0.0001f);
+        assertEquals(1.535f, result[1535], 0.0001f);
+    }
+}


### PR DESCRIPTION
## Summary
- Create  that converts  to/from JSON string for MariaDB VECTOR storage
- Apply  annotation to  field
- Add comprehensive test coverage with 11 test cases

## Files Changed
-  - New JPA AttributeConverter
-  - Added @Convert annotation
-  - 11 test cases covering edge cases

## Testing
All 93 domain module tests pass.

Fixes #76