### PR TITLE
fix(#78): Remove unused contentVector from Page entity

### DIFF
--- a/backend/llm-wiki-domain/src/main/java/com/llmwiki/domain/page/entity/Page.java
+++ b/backend/llm-wiki-domain/src/main/java/com/llmwiki/domain/page/entity/Page.java
@@ -47,12 +47,6 @@ public class Page {
     @Column(columnDefinition = "TEXT")
     private String aiScoreDetail;
 
-    /**
-     * 文档级向量嵌入（JSON数组字符串存储，用于H2兼容；生产环境使用MariaDB VECTOR）
-     */
-    @Column(name = "content_vector", columnDefinition = "TEXT")
-    private String contentVector;
-
     private UUID sourceDocId;
 
     private String approvedBy;

--- a/backend/llm-wiki-service/src/main/java/com/llmwiki/service/pipeline/PipelineService.java
+++ b/backend/llm-wiki-service/src/main/java/com/llmwiki/service/pipeline/PipelineService.java
@@ -548,27 +548,7 @@ public class PipelineService {
             pageTagRepo.save(PageTag.builder().pageId(page.getId()).tag(tag).build());
         }
 
-        // Generate document-level vector embedding
-        embedPageContent(page);
-
         return page;
-    }
-
-    private void embedPageContent(Page page) {
-        try {
-            float[] embedding = embeddingClient.embed(page.getContent());
-            // Store as JSON array string for H2 compatibility
-            StringBuilder sb = new StringBuilder("[");
-            for (int i = 0; i < embedding.length; i++) {
-                if (i > 0) sb.append(",");
-                sb.append(embedding[i]);
-            }
-            sb.append("]");
-            page.setContentVector(sb.toString());
-            pageRepo.save(page);
-        } catch (Exception e) {
-            log.warn("Failed to embed page content {}: {}", page.getId(), e.getMessage());
-        }
     }
 
     private String generateUniqueSlug(String title) {

--- a/backend/llm-wiki-web/src/main/resources/db/migration/V10__drop_content_vector.sql
+++ b/backend/llm-wiki-web/src/main/resources/db/migration/V10__drop_content_vector.sql
@@ -1,0 +1,3 @@
+-- Drop unused content_vector column from pages table
+-- This column was added to the JPA entity but never used; it was not migrated to the database schema.
+ALTER TABLE pages DROP COLUMN IF EXISTS content_vector;


### PR DESCRIPTION
## Summary
Remove the unused `contentVector` field from the `Page` JPA entity and its associated code.

## Changes
- **Page.java**: Removed `contentVector` field and its `@Column` annotation
- **PipelineService.java**: Removed the `embedPageContent()` method and its call — the `EmbeddingClient` remains in use for other purposes
- **V10__drop_content_vector.sql**: Added Flyway migration to safely drop the `content_vector` column if it exists

## Testing
All 528 tests pass (BUILD SUCCESS).